### PR TITLE
Notify_ColorChanged patch (mainly) for Medieval 2

### DIFF
--- a/1.6/Source/HarmonyPatches/ThingWithComps_Notify_ColorChanged_Patch.cs
+++ b/1.6/Source/HarmonyPatches/ThingWithComps_Notify_ColorChanged_Patch.cs
@@ -1,0 +1,43 @@
+using HarmonyLib;
+using Verse;
+
+namespace Worldbuilder
+{
+    /// <summary>
+    /// Vanilla Expanded Factions: Medieval 2 seems to call a ColorChanged for the graphics of everything on the map after you change heraldry.
+    /// I.e. ANY interaction with the heraldry editing menu calls ColorChanged for everything on the map. 
+    ///
+    /// <para/>
+    /// This patch simply reapplies the graphics set via Worldbuilder afterwards.
+    /// It'll also be called after any other mod does Notify_ColorChanged, of course, not just VFE: Medieval 2.
+    /// 
+    /// <para/>
+    /// As we're only setting the graphics for the set of buildings the user edited manually it should be compatible with everything else.
+    /// However, I can't foresee all cases; I think it's technically possible one mod's customization might overwrite another's.
+    /// 
+    /// <para/>
+    /// <see
+    ///     href="https://github.com/Vanilla-Expanded/VanillaFactionsExpanded-Medieval2/blob/438742256f54a965dc46da5f38a9ccfa5d4e19c9/1.6/Source/VFEMedieval/Heraldics/EditHeraldic.cs#L447-L471">
+    ///      Relevant VFE code.
+    /// </see>
+    /// </summary>
+    [HotSwappable]
+    [HarmonyPatch(typeof(ThingWithComps), nameof(ThingWithComps.Notify_ColorChanged))]
+    [HarmonyPriority(Priority.Last)]
+    public static class ThingWithComps_Notify_ColorChanged_Patch
+    {
+        public static void Postfix(ThingWithComps __instance)
+        {
+            if (__instance is Pawn) return;
+
+            var customizationData = __instance.GetCustomizationData();
+            if (customizationData == null) return;
+
+            var customGraphic = customizationData.GetGraphic(__instance);
+            if (customGraphic == null) return;
+
+            __instance.graphicInt = customGraphic;
+            __instance.styleGraphicInt = customGraphic;
+        }
+    }
+}


### PR DESCRIPTION
Part of the issue is described here: https://github.com/fernyrepos/Worldbuilder/issues/4

I've used this locally for a few days on big colonies; couldn't find any issues. There's a second part that makes Dubs Paint Shop and any other mods that paint things using `CompColorable` "more compatible", but I'll leave that for the future as there's some weird cases.

Performance-wise (as far as I understand and tested) this should only pop up when the user is actively painting something; i.e. no real performance loss.

<img width="934" height="588" alt="image" src="https://github.com/user-attachments/assets/bf6600f7-5eac-4031-882c-fb497ea79264" />





------
Without patch

https://github.com/user-attachments/assets/5e8840ad-b937-4fb0-b4b1-022fc74c2735



With patch

https://github.com/user-attachments/assets/2b1fdaf4-4c5f-40b4-ba2f-2240b65a411e

